### PR TITLE
Add FastAPI RRG service and React demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,20 @@ uvicorn backend.app:app --reload
 
 The endpoint returns JSON suitable for the front‑end.
 
+### Populating data from yfinance
+
+If your database does not yet contain prices, you can fetch them from
+[yfinance](https://pypi.org/project/yfinance/). The ticker symbol for the
+S&P 500 ETF is `SPY`. A helper script is provided to load daily (`1d`)
+prices into the table:
+
+```bash
+python backend/load_yfinance.py SPY,AAPL,MSFT --interval 1d --env devtest
+```
+
+This downloads roughly two years of daily data and upserts it into the
+`stock_ohlcv` table so that the RRG endpoint can operate.
+
 ## Front‑end
 
 `frontend/index.html` is a small React page that fetches RRG data and

--- a/README.md
+++ b/README.md
@@ -33,6 +33,15 @@ The endpoint returns JSON suitable for the front‑end.
 ## Front‑end
 
 `frontend/index.html` is a small React page that fetches RRG data and
-displays it using Chart.js. Open the file in a browser while the API is
-running.
+displays it using Chart.js. Because it expects the API at `http://localhost:8000`,
+run a simple HTTP server from the `frontend` directory and open the page
+through that server:
+
+```bash
+cd frontend
+python3 -m http.server 8080
+```
+
+Then browse to <http://localhost:8080/index.html> while the FastAPI
+service is running.
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,38 @@
+# Relative Rotation Graph Service
+
+This project provides a small FastAPI service and a simple React-based
+front‑end to display Relative Rotation Graphs (RRG) for NYSE tickers.
+
+## Backend
+
+The service reads PostgreSQL connection information from AWS SSM
+parameters under `/stockapp/<environment>/PGHOST` etc. The AWS profile
+is taken from the invoking shell session.
+
+To run the API locally:
+
+```bash
+pip install -r backend/requirements.txt
+uvicorn backend.app:app --reload
+```
+
+### Endpoint
+
+`GET /rrg`
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `tickers` | Comma separated tickers to plot | required |
+| `benchmark` | Benchmark ticker | `SPY` |
+| `interval` | Price interval (e.g. `1d`) | `1d` |
+| `tail` | Number of points in each tail | `30` |
+| `env` | SSM environment prefix | `devtest` |
+
+The endpoint returns JSON suitable for the front‑end.
+
+## Front‑end
+
+`frontend/index.html` is a small React page that fetches RRG data and
+displays it using Chart.js. Open the file in a browser while the API is
+running.
+

--- a/backend/app.py
+++ b/backend/app.py
@@ -1,10 +1,19 @@
 from typing import List
 from fastapi import FastAPI, Query
+from fastapi.middleware.cors import CORSMiddleware
 import boto3
 import psycopg2
 import pandas as pd
 
 app = FastAPI()
+
+# allow requests from the demo page
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 
 
 def get_db_config(env: str) -> dict:

--- a/backend/app.py
+++ b/backend/app.py
@@ -1,0 +1,91 @@
+from typing import List
+from fastapi import FastAPI, Query
+import boto3
+import psycopg2
+import pandas as pd
+
+app = FastAPI()
+
+
+def get_db_config(env: str) -> dict:
+    """Load database configuration from AWS SSM."""
+    ssm = boto3.client("ssm")
+    keys = ["PGHOST", "PGPORT", "PGUSER", "PGPASSWORD"]
+    cfg = {}
+    for key in keys:
+        name = f"/stockapp/{env}/{key}"
+        resp = ssm.get_parameter(Name=name, WithDecryption=True)
+        cfg[key] = resp["Parameter"]["Value"]
+    return cfg
+
+
+def get_connection(env: str):
+    cfg = get_db_config(env)
+    conn = psycopg2.connect(
+        host=cfg["PGHOST"],
+        port=cfg["PGPORT"],
+        user=cfg["PGUSER"],
+        password=cfg["PGPASSWORD"],
+        dbname="postgres",
+    )
+    return conn
+
+
+def fetch_prices(conn, tickers: List[str], interval: str, days: int) -> pd.DataFrame:
+    placeholders = ",".join(["%s"] * len(tickers))
+    params: List = [interval] + tickers + [f"{days} days"]
+    query = (
+        f"""
+        SELECT ticker, ts, close
+        FROM stock_ohlcv
+        WHERE interval = %s AND ticker IN ({placeholders})
+          AND ts >= NOW() - INTERVAL %s
+        ORDER BY ts
+        """
+    )
+    df = pd.read_sql(query, conn, params=params)
+    return df
+
+
+def compute_rrg(df: pd.DataFrame, tickers: List[str], benchmark: str, tail: int):
+    pivot = df.pivot(index="ts", columns="ticker", values="close").sort_index()
+    benchmark_series = pivot[benchmark]
+    rrg = {}
+    for t in tickers:
+        if t == benchmark:
+            continue
+        rel = pivot[t] / benchmark_series
+        ratio = rel / rel.iloc[0]
+        momentum = ratio.diff()
+        points = [
+            {
+                "x": float(ratio.iloc[i]),
+                "y": float(momentum.iloc[i]),
+                "date": ratio.index[i].isoformat(),
+            }
+            for i in range(-tail, 0)
+            if i < len(ratio)
+        ]
+        rrg[t] = points
+    return rrg
+
+
+@app.get("/rrg")
+def rrg(
+    tickers: str = Query(..., description="Comma separated list of tickers"),
+    benchmark: str = Query("SPY"),
+    interval: str = Query("1d"),
+    tail: int = Query(30),
+    env: str = Query("devtest"),
+):
+    symbols = [t.strip().upper() for t in tickers.split(",") if t.strip()]
+    all_symbols = symbols + [benchmark]
+    conn = get_connection(env)
+    try:
+        df = fetch_prices(conn, all_symbols, interval, tail * 10)
+    finally:
+        conn.close()
+    data = compute_rrg(df, symbols, benchmark, tail)
+    return {"benchmark": benchmark, "points": data}
+
+

--- a/backend/load_yfinance.py
+++ b/backend/load_yfinance.py
@@ -1,0 +1,87 @@
+import argparse
+from typing import List
+import pandas as pd
+import yfinance as yf
+import psycopg2
+from .app import get_db_config
+
+
+def get_connection(env: str):
+    cfg = get_db_config(env)
+    return psycopg2.connect(
+        host=cfg["PGHOST"],
+        port=cfg["PGPORT"],
+        user=cfg["PGUSER"],
+        password=cfg["PGPASSWORD"],
+        dbname="postgres",
+    )
+
+
+def fetch_yf(ticker: str, interval: str) -> pd.DataFrame:
+    df = yf.download(ticker, interval=interval, period="2y")
+    df = df.reset_index()
+    df.rename(
+        columns={
+            "Date": "ts",
+            "Open": "open",
+            "High": "high",
+            "Low": "low",
+            "Close": "close",
+            "Volume": "volume",
+        },
+        inplace=True,
+    )
+    df["ticker"] = ticker
+    df["interval"] = interval
+    return df
+
+
+def insert_prices(conn, df: pd.DataFrame):
+    with conn.cursor() as cur:
+        for row in df.itertuples(index=False):
+            cur.execute(
+                """
+                INSERT INTO stock_ohlcv
+                    (ticker, interval, ts, open, high, low, close, volume)
+                VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
+                ON CONFLICT (ticker, interval, ts) DO UPDATE SET
+                    open = EXCLUDED.open,
+                    high = EXCLUDED.high,
+                    low = EXCLUDED.low,
+                    close = EXCLUDED.close,
+                    volume = EXCLUDED.volume
+                """,
+                (
+                    row.ticker,
+                    row.interval,
+                    row.ts,
+                    row.open,
+                    row.high,
+                    row.low,
+                    row.close,
+                    row.volume,
+                ),
+            )
+    conn.commit()
+
+
+def main(tickers: List[str], interval: str, env: str):
+    conn = get_connection(env)
+    try:
+        for t in tickers:
+            df = fetch_yf(t, interval)
+            insert_prices(conn, df)
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Load OHLCV data from yfinance into the database"
+    )
+    parser.add_argument("tickers", help="Comma separated list of tickers")
+    parser.add_argument("--interval", default="1d", help="yfinance interval")
+    parser.add_argument("--env", default="devtest", help="SSM environment")
+    args = parser.parse_args()
+    tickers = [t.strip().upper() for t in args.tickers.split(",") if t.strip()]
+    main(tickers, args.interval, args.env)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -3,3 +3,4 @@ uvicorn
 boto3
 psycopg2-binary
 pandas
+yfinance

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,5 @@
+fastapi
+uvicorn
+boto3
+psycopg2-binary
+pandas

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -21,7 +21,7 @@ function App(){
   const [tail, setTail] = React.useState(30);
   const [data, setData] = React.useState(null);
   const fetchData = async () => {
-    const resp = await fetch(`/rrg?tickers=${tickers}&tail=${tail}`);
+    const resp = await fetch(`http://localhost:8000/rrg?tickers=${tickers}&tail=${tail}`);
     const json = await resp.json();
     setData(json);
   };

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Relative Rotation Graph</title>
+  <script src="https://unpkg.com/react@17/umd/react.development.js" crossorigin></script>
+  <script src="https://unpkg.com/react-dom@17/umd/react-dom.development.js" crossorigin></script>
+  <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-zoom@1.2.1"></script>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 20px; }
+    #chart { max-width: 900px; height: 600px; }
+  </style>
+</head>
+<body>
+  <div id="root"></div>
+<script type="text/babel">
+function App(){
+  const [tickers, setTickers] = React.useState('AAPL,MSFT,GOOGL');
+  const [tail, setTail] = React.useState(30);
+  const [data, setData] = React.useState(null);
+  const fetchData = async () => {
+    const resp = await fetch(`/rrg?tickers=${tickers}&tail=${tail}`);
+    const json = await resp.json();
+    setData(json);
+  };
+  React.useEffect(()=>{fetchData();},[]);
+  React.useEffect(()=>{
+    if(!data) return;
+    const ctx = document.getElementById('chart').getContext('2d');
+    const datasets = Object.entries(data.points).map(([ticker,points])=>({
+      label: ticker,
+      data: points.map(p=>({x:p.x,y:p.y})),
+      fill:false,
+      showLine:true,
+      borderColor:`hsl(${Math.random()*360},70%,50%)`
+    }));
+    if(window.myChart){window.myChart.destroy();}
+    window.myChart = new Chart(ctx, {
+      type:'scatter',
+      data:{datasets},
+      options:{
+        parsing:false,
+        plugins:{
+          legend:{position:'bottom'},
+          zoom:{zoom:{wheel:{enabled:true},pinch:{enabled:true},mode:'xy'}}
+        },
+        scales:{x:{title:{display:true,text:'RS-Ratio'}},y:{title:{display:true,text:'RS-Momentum'}}}
+      }
+    });
+  },[data]);
+  return (
+    <div>
+      <div>
+        <label>Tickers: <input value={tickers} onChange={e=>setTickers(e.target.value)} /></label>
+        <label>Tail: <input type="number" value={tail} onChange={e=>setTail(+e.target.value)} /></label>
+        <button onClick={fetchData}>Draw</button>
+      </div>
+      <canvas id="chart"></canvas>
+    </div>
+  );
+}
+ReactDOM.render(<App/>, document.getElementById('root'));
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add README with instructions
- implement FastAPI backend that loads PostgreSQL config from SSM and produces RRG data
- supply requirements.txt for backend
- add simple React demo page using Chart.js

## Testing
- `pip install -r backend/requirements.txt`
- `python -c "import backend.app; print('ok')"`
- `uvicorn backend.app:app --port 8000` *(server started and then was terminated)*

------
https://chatgpt.com/codex/tasks/task_e_6878a3e0c0688330b87bcc4dfd575ff9