### PR TITLE
Add price prepping with test

### DIFF
--- a/prices.py
+++ b/prices.py
@@ -1,0 +1,30 @@
+import pandas as pd
+import yfinance as yf
+
+
+def download_prices(ticker: str, interval: str = '1m', period: str = '1d') -> pd.DataFrame:
+    """Download price data using yfinance."""
+    return yf.download(ticker, interval=interval, period=period)
+
+
+def prepare_prices(df: pd.DataFrame, ticker: str, interval: str) -> pd.DataFrame:
+    """Flatten columns and prepare DataFrame for insertion."""
+    df.columns = [c[0] if isinstance(c, tuple) else c for c in df.columns]
+    df = df.rename(columns={
+        'Open': 'open',
+        'High': 'high',
+        'Low': 'low',
+        'Close': 'close',
+        'Volume': 'volume',
+    })
+    df['ticker'] = ticker
+    df['interval'] = interval
+    df.reset_index(inplace=True)
+    return df
+
+
+def insert_prices(df: pd.DataFrame) -> bool:
+    """Simulate inserting prices by reading row.ticker."""
+    for row in df.itertuples(index=False):
+        _ = row.ticker  # access ticker attribute
+    return True

--- a/test_prices.py
+++ b/test_prices.py
@@ -1,0 +1,16 @@
+import pandas as pd
+from pandas import MultiIndex
+from prices import prepare_prices, insert_prices
+
+def test_insert_prices_accesses_ticker():
+    columns = MultiIndex.from_product([
+        ['Open', 'High', 'Low', 'Close', 'Volume'],
+        ['AAPL']
+    ])
+    data = [
+        [1, 2, 3, 4, 5],
+        [6, 7, 8, 9, 10]
+    ]
+    df = pd.DataFrame(data, index=pd.date_range('2025-01-01', periods=2, freq='D'), columns=columns)
+    prepared = prepare_prices(df, 'AAPL', '1d')
+    assert insert_prices(prepared) is True


### PR DESCRIPTION
## Summary
- add `prices.py` for downloading and preparing price data
- flatten multi-index columns, rename fields, add `ticker` & `interval`
- provide `insert_prices` stub that reads `row.ticker`
- add pytest ensuring `insert_prices` can access `row.ticker`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b35cecf248330982e44d71d8da080